### PR TITLE
Migrate to aeson 2.0+ and fix GHC 9.6+ compatibility

### DIFF
--- a/json-rpc-client.cabal
+++ b/json-rpc-client.cabal
@@ -10,10 +10,7 @@ synopsis:            JSON-RPC 2.0 on the client side.
 build-type:          Simple
 extra-source-files:  changelog.md
 cabal-version:       >=1.10
-tested-with:         GHC == 7.0.4, GHC == 7.4.2, GHC == 7.6.3,
-                     GHC == 7.8.3, GHC == 7.10.1, GHC == 7.10.3,
-                     GHC == 8.0.1, GHC == 8.0.2, GHC == 8.2.2,
-                     GHC == 8.4.1, GHC == 8.4.4, GHC == 8.6.1
+tested-with:         GHC == 9.6.6, GHC == 9.8.4
 homepage:            https://github.com/grayjay/json-rpc-client
 bug-reports:         https://github.com/grayjay/json-rpc-client/issues
 description:         Functions for creating a JSON-RPC 2.0 client.  See
@@ -40,15 +37,15 @@ flag demo
 library
   exposed-modules:     Network.JsonRpc.Client
                        Network.JsonRpc.ServerAdapter
-  build-depends:       base >=4.3.1 && <4.13,
+  build-depends:       base >=4.3.1 && <4.21,
                        json-rpc-server >=0.2 && <0.3,
-                       aeson >=0.7 && <1.5,
-                       bytestring >=0.9.1 && <0.11,
-                       mtl >=2.2.1 && <2.3,
-                       text >=0.11.2 && <1.3,
+                       aeson >=2.0 && <2.3,
+                       bytestring >=0.9.1 && <0.13,
+                       mtl >=2.2.1 && <2.4,
+                       text >=0.11.2 && <2.2,
                        unordered-containers >=0.2.3 && <0.3,
-                       vector >=0.10 && <0.13,
-                       vector-algorithms >=0.5.4 && <0.9
+                       vector >=0.10 && <0.14,
+                       vector-algorithms >=0.5.4 && <0.10
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -87,7 +84,7 @@ executable demo-client
     build-depends:       base,
                          json-rpc-client,
                          json-rpc-server,
-                         process >=1.1.0 && <1.7,
+                         process >=1.1.0 && <1.8,
                          aeson,
                          bytestring >=0.9.2,
                          mtl,
@@ -114,7 +111,7 @@ test-suite tests
                        unordered-containers,
                        vector,
                        HUnit >=1.2.4 && <1.7,
-                       QuickCheck >=2.4.2 && <2.14,
+                       QuickCheck >=2.4.2 && <2.16,
                        test-framework >=0.6 && <0.9,
                        test-framework-hunit >=0.3 && <0.4,
                        test-framework-quickcheck2 >=0.3 && <0.4

--- a/src/Network/JsonRpc/Client.hs
+++ b/src/Network/JsonRpc/Client.hs
@@ -50,14 +50,17 @@ import qualified Data.Aeson as A
 import Data.Aeson ((.=), (.:))
 import Data.Text (Text (), pack)
 import Data.ByteString.Lazy (ByteString)
-import qualified Data.HashMap.Strict as H
+import qualified Data.Aeson.Key as AK
+import qualified Data.Aeson.KeyMap as KM
 import Data.Ord (comparing)
 import Data.Maybe (catMaybes)
 import qualified Data.Vector as V
 import qualified Data.Vector.Algorithms.Intro as VA
 import Control.Arrow ((&&&))
 import Control.Monad (liftM)
-import Control.Monad.Except (ExceptT (..), throwError, lift, (<=<))
+import Control.Monad.Except (ExceptT (..), throwError)
+import Control.Monad.Trans (lift)
+import Control.Monad ((<=<))
 import Control.Applicative (Alternative (..), (<|>))
 
 #if !MIN_VERSION_base(4,8,0)
@@ -109,7 +112,7 @@ infixr :::
 toBatchFunction :: ClientFunction ps r f =>
                    Signature ps r -- ^ Method signature.
                 -> f              -- ^ Client-side function with a return type of @'Batch' r@.
-toBatchFunction s@(Signature name params) = _toBatch name params (resultType s) H.empty
+toBatchFunction s@(Signature name params) = _toBatch name params (resultType s) KM.empty
 
 -- | Creates a function for calling a JSON-RPC method as a notification and as part of a batch request.
 toBatchFunction_ :: (ClientFunction ps r f, ComposeMultiParam (Batch r -> Batch ()) f g) =>
@@ -241,7 +244,7 @@ instance A.FromJSON r => ClientFunction () r (Batch r) where
                                                "Client received wrong result type: " ++ msg
 
 instance (ClientFunction ps r f, A.ToJSON a) => ClientFunction (a ::: ps) r (a -> f) where
-    _toBatch name (p ::: ps) rt priorArgs a = let newArgs = H.insert p (A.toJSON a) priorArgs
+    _toBatch name (p ::: ps) rt priorArgs a = let newArgs = KM.insert (AK.fromText p) (A.toJSON a) priorArgs
                                               in _toBatch name ps rt newArgs
 
 -- | Relationship between a function ('g') taking any number of arguments and yielding a @'Batch' a@,
@@ -269,7 +272,7 @@ instance A.ToJSON IdRequest where
                                      , Just $ "method" .= idRqMethod rq
                                      , ("id" .=) <$> idRqId rq
                                      , let params = idRqParams rq
-                                       in if H.null params
+                                       in if KM.null params
                                           then Nothing
                                           else Just $ "params" .= params ]
 

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -14,10 +14,12 @@ import qualified Data.ByteString.Lazy as B
 import Data.Maybe (fromJust)
 import Data.Ratio ((%))
 import Data.Scientific (Scientific)
-import qualified Data.HashMap.Strict as M
+import qualified Data.Aeson.Key as AK
+import qualified Data.Aeson.KeyMap as KM
 import qualified Data.Vector as V
 import Control.Monad.Except (runExceptT, throwError)
-import Control.Monad.State (State, runState, modify, when)
+import Control.Monad (when)
+import Control.Monad.State (State, runState, modify)
 import Test.HUnit hiding (State, Test)
 import Test.Framework (Test)
 import Test.Framework.Providers.HUnit (testCase)
@@ -196,10 +198,13 @@ subtractWithConstServer response = toFunction server subtractSig 1 2
 
 idModifyingServer :: (Scientific -> Scientific) -> Connection RequestCount
 idModifyingServer f = responseModifyingServer modifyIds
-    where modifyIds (A.Array rs) = A.Array $ V.map modifyIds rs
-          modifyIds (A.Object r) = A.Object $ M.adjust modifyId "id" r
-              where modifyId (A.Number i) = A.Number $ f i
-                    modifyId x = x
+    where idKey = AK.fromText "id"
+          modifyId (A.Number i) = A.Number $ f i
+          modifyId x = x
+          modifyIds (A.Array rs) = A.Array $ V.map modifyIds rs
+          modifyIds (A.Object r) = A.Object $ case KM.lookup idKey r of
+              Nothing -> r
+              Just v  -> KM.insert idKey (modifyId v) r
           modifyIds x = x
 
 responseModifyingServer :: (A.Value -> A.Value) -> Connection RequestCount


### PR DESCRIPTION
## Summary

Adds compatibility with aeson 2.0+ and GHC 9.6+.

### aeson 2.0 migration

- Replace `Data.HashMap.Strict` with `Data.Aeson.Key` / `Data.Aeson.KeyMap`
- Update `H.empty` → `KM.empty`, `H.insert` → `KM.insert` with `AK.fromText`, `H.null` → `KM.null`

### GHC 9.6 compatibility

- `(<=<)` is no longer re-exported from `Control.Monad.Except` in mtl 2.3+; import it from `Control.Monad` directly
- Import `lift` from `Control.Monad.Trans` separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)